### PR TITLE
Fix meeting title and tab cleanup

### DIFF
--- a/script.min.js
+++ b/script.min.js
@@ -12,7 +12,7 @@ async function startVideoCall() {
   const teamName = "free";
   const apiUrl = `https://api.digitalsamba.com/api/public/${teamName}`;
   const name = document.getElementById("name").value.trim();
-  const htmlTitle = `${name}\'s Digital Samba Meeting`;
+  const htmlTitle = `${name}'s Digital Samba Meeting`;
 
   if (!name) {
     alert("Please enter your name.");
@@ -64,6 +64,7 @@ async function startVideoCall() {
       ? (newTab.location.href = joinUrl)
       : (window.location.href = joinUrl);
   } catch (error) {
+    if (newTab) newTab.close();
     alert("Failed to start the video call.");
   }
 }


### PR DESCRIPTION
## Summary
- fix HTML title escaping for meetings
- close blank tab if starting video call fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684db7f4367c8329998b1aa146d37368