### PR TITLE
Fix startFirework toggle check

### DIFF
--- a/script.min.js
+++ b/script.min.js
@@ -73,7 +73,7 @@ function handleKeyPress(event) {
 }
 
 function startFirework(event) {
-  const e2eeEnabled = document.getElementById("e2eeToggle").checked;
+  const e2eeEnabled = event.target.checked;
 
   if (e2eeEnabled) {
     for (let j = 0; j < 3; j++) {


### PR DESCRIPTION
## Summary
- rely on the click event to determine if E2EE is enabled

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dba96d5bc8329a94bd28108313003