### PR TITLE
Fix vertical position jumping between tabs

### DIFF
--- a/style.min.css
+++ b/style.min.css
@@ -13,15 +13,15 @@ body {
   background-color: #fff;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
-  height: 100vh;
+  min-height: 100vh;
   margin: 0;
-  padding: 0 20px;
+  padding: 10vh 20px 0;
 }
 
 .logo-container {
-  margin-top: -20vh;
+  margin-top: 0;
   margin-bottom: 40px;
 }
 


### PR DESCRIPTION
## Summary
- anchor page layout to the top to avoid vertical jumping when switching tabs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dbf17a0cc8329b73987a7a3f7eeb7