### PR TITLE
Improve tooltip centering and edge handling

### DIFF
--- a/script.min.js
+++ b/script.min.js
@@ -124,6 +124,21 @@ function startFirework(event) {
   }
 }
 // Tooltip
+function positionTooltip(tip) {
+  tip.style.left = '50%';
+  tip.style.right = 'auto';
+  tip.style.transform = 'translateX(-50%)';
+  const rect = tip.getBoundingClientRect();
+  if (rect.right > window.innerWidth) {
+    tip.style.left = 'auto';
+    tip.style.right = '0';
+    tip.style.transform = 'translateX(0)';
+  } else if (rect.left < 0) {
+    tip.style.left = '0';
+    tip.style.right = 'auto';
+    tip.style.transform = 'translateX(0)';
+  }
+}
 document.querySelectorAll('.info-icon').forEach(function(icon) {
   let tooltip = icon.querySelector('.tooltip');
 
@@ -141,6 +156,7 @@ document.querySelectorAll('.info-icon').forEach(function(icon) {
     if (!isVisible) {
       tooltip.style.visibility = 'visible';
       tooltip.style.opacity = '1';
+      positionTooltip(tooltip);
     }
   });
 

--- a/style.min.css
+++ b/style.min.css
@@ -171,7 +171,7 @@ input:checked + .slider:before {
   position: absolute;
   bottom: 125%;
   left: 50%;
-  transform: translateX(-80%);
+  transform: translateX(-50%);
   opacity: 0;
   transition: opacity 0.3s;
   font-size: 12px;


### PR DESCRIPTION
## Summary
- keep tooltips centered on their icons
- adjust tooltip position if it would overflow off‑screen

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dc193a8148329b2c19c35ff084aac