### PR TITLE
Add schedule tab waiting list

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,17 +186,22 @@
 
     <!-- Schedule -->
     <div id="schedule-tab" class="tab-content" style="display: none">
-      <div class="input-container" id="scheduleForm">
+      <form class="input-container waiting-list-form" id="scheduleForm">
         <div class="instructions">
-          To schedule meetings and webinars, you'll need to sign up to a Digital Samba Free account.
+          To schedule meetings and webinars, you'll need a Digital Samba Free account. Join our waiting list and we'll notify you as soon as it's ready.
         </div>
-        <div class="info-icon">
-          <button>Sign up now</button>
-          <span class="tooltip">
-            Accounts are coming soon. Please check back here in a few weeks or <a href="" target="_blank">click here</a> to be notified.
-          </span>
-        </div>
-      </div>
+        <input
+          type="email"
+          id="waitingEmail"
+          placeholder="Your email address"
+          required
+        />
+        <label class="checkbox-container">
+          <input type="checkbox" id="marketingConsent" required />
+          I agree to receive updates and marketing communication from Digital Samba.
+        </label>
+        <button type="submit">Join Waiting List</button>
+      </form>
     </div>
 
     <!-- Descriptive Text -->

--- a/script.min.js
+++ b/script.min.js
@@ -238,6 +238,23 @@ document.getElementById("copyLinkButton").addEventListener("click", function () 
   });
 });
 
+// Waiting list form submission
+document.getElementById("scheduleForm").addEventListener("submit", function (e) {
+  e.preventDefault();
+  const email = document.getElementById("waitingEmail").value.trim();
+  const consent = document.getElementById("marketingConsent").checked;
+  if (!email) {
+    alert("Please enter your email address.");
+    return;
+  }
+  if (!consent) {
+    alert("Please accept marketing communication to join the waiting list.");
+    return;
+  }
+  alert("Thank you! We'll let you know when scheduling becomes available.");
+  this.reset();
+});
+
 
 
 

--- a/style.min.css
+++ b/style.min.css
@@ -361,3 +361,16 @@ a:visited {
   color: #000;
   background: white;
 }
+
+/* Waiting list styles */
+.waiting-list-form label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #333;
+}
+
+.waiting-list-form input[type="checkbox"] {
+  width: auto;
+}


### PR DESCRIPTION
## Summary
- replace sign-up tooltip in the schedule tab with an email waiting list form
- style the waiting list checkbox and label
- add JS to handle dummy waiting list submissions

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684dcbd68f78832981577cc83981f34b