### PR TITLE
Fix consent checkbox visibility

### DIFF
--- a/style.min.css
+++ b/style.min.css
@@ -113,7 +113,7 @@ button:hover {
   height: 0;
 }
 
-input[type="checkbox"] {
+.switch input[type="checkbox"] {
   -webkit-appearance: none;
 }
 
@@ -365,7 +365,7 @@ a:visited {
 /* Waiting list styles */
 .waiting-list-form label {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
   font-size: 14px;
   color: #333;
@@ -373,4 +373,6 @@ a:visited {
 
 .waiting-list-form input[type="checkbox"] {
   width: auto;
+  appearance: checkbox;
+  -webkit-appearance: checkbox;
 }


### PR DESCRIPTION
## Summary
- show default checkbox style for the waiting list form
- adjust waiting list checkbox layout for mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e690097048329a7907f5b60572dde