### PR TITLE
Enhance consent checkbox and messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,6 +190,7 @@
         <div class="instructions">
           To schedule meetings and webinars, you'll need a Digital Samba Free account. Join our waiting list and we'll notify you as soon as it's ready.
         </div>
+        <p id="scheduleError" class="error-message" style="display: none"></p>
         <input
           type="email"
           id="waitingEmail"
@@ -198,7 +199,9 @@
         />
         <label class="checkbox-container">
           <input type="checkbox" id="marketingConsent" required />
-          I agree to receive updates and marketing communication from Digital Samba.
+          <span>
+            I agree to receive updates and marketing communication from Digital Samba.<span class="required-indicator">*</span>
+          </span>
         </label>
         <button type="submit">Join Waiting List</button>
       </form>

--- a/script.min.js
+++ b/script.min.js
@@ -241,16 +241,20 @@ document.getElementById("copyLinkButton").addEventListener("click", function () 
 // Waiting list form submission
 document.getElementById("scheduleForm").addEventListener("submit", function (e) {
   e.preventDefault();
+  const errorEl = document.getElementById("scheduleError");
   const email = document.getElementById("waitingEmail").value.trim();
   const consent = document.getElementById("marketingConsent").checked;
   if (!email) {
-    alert("Please enter your email address.");
+    errorEl.textContent = "Please enter your email address.";
+    errorEl.style.display = "block";
     return;
   }
   if (!consent) {
-    alert("Please accept marketing communication to join the waiting list.");
+    errorEl.textContent = "Please accept marketing communication to join the waiting list.";
+    errorEl.style.display = "block";
     return;
   }
+  errorEl.style.display = "none";
   alert("Thank you! We'll let you know when scheduling becomes available.");
   this.reset();
 });

--- a/style.min.css
+++ b/style.min.css
@@ -376,3 +376,14 @@ a:visited {
   appearance: checkbox;
   -webkit-appearance: checkbox;
 }
+
+.error-message {
+  color: #f06859;
+  font-size: 14px;
+  margin: 0 0 10px;
+}
+
+.required-indicator {
+  color: #f06859;
+  margin-left: 2px;
+}


### PR DESCRIPTION
## Summary
- make consent checkbox clearly required and keep spacing
- add inline validation error display
- style error messages to match site look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e729d3904832983c8cef2ef7dc42d