### PR TITLE
Enhance inline validation styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,7 @@
             </span>
           </div>
         </div>
+        <p id="startError" class="error-message" style="display: none"></p>
       </div>
     </div>
 
@@ -163,6 +164,7 @@
             </span>
           </div>
         </div>
+        <p id="generateError" class="error-message" style="display: none"></p>
       </div>
       <!-- Link Box -->
       <div id="generatedBox" style="display: none">
@@ -191,6 +193,7 @@
           To schedule meetings and webinars, you'll need a Digital Samba Free account. Join our waiting list and we'll notify you as soon as it's ready.
         </div>
         <p id="scheduleError" class="error-message" style="display: none"></p>
+        <p id="scheduleSuccess" class="success-message" style="display: none"></p>
         <input
           type="email"
           id="waitingEmail"

--- a/script.min.js
+++ b/script.min.js
@@ -14,8 +14,12 @@ async function startVideoCall() {
   const name = document.getElementById("name").value.trim();
   const htmlTitle = `${name}'s Digital Samba Meeting`;
 
+  const errorEl = document.getElementById("startError");
+  errorEl.style.display = "none";
+
   if (!name) {
-    alert("Please enter your name.");
+    errorEl.textContent = "Please enter your name.";
+    errorEl.style.display = "block";
     return;
   }
 
@@ -65,7 +69,8 @@ async function startVideoCall() {
       : (window.location.href = joinUrl);
   } catch (error) {
     if (newTab) newTab.close();
-    alert("Failed to start the video call.");
+    errorEl.textContent = "Failed to start the video call.";
+    errorEl.style.display = "block";
   }
 }
 
@@ -183,6 +188,9 @@ async function generateRoomLink() {
   const apiUrl = `https://api.digitalsamba.com/api/public/${teamName}`;
   const e2eeEnabled = document.getElementById("e2eeToggleGenerate").checked;
 
+  const errorEl = document.getElementById("generateError");
+  errorEl.style.display = "none";
+
   const btn = document.querySelector("#generateForm button");
   btn.disabled = true;
   btn.textContent = "Generating...";
@@ -218,7 +226,8 @@ async function generateRoomLink() {
     const copyBtn = document.getElementById("copyLinkButton");
     copyBtn.innerHTML = "Copy link";
   } catch (error) {
-    alert("Failed to generate the room link.");
+    errorEl.textContent = "Failed to generate the room link.";
+    errorEl.style.display = "block";
   } finally {
     btn.disabled = false;
     btn.textContent = "Generate Room Link";
@@ -242,6 +251,8 @@ document.getElementById("copyLinkButton").addEventListener("click", function () 
 document.getElementById("scheduleForm").addEventListener("submit", function (e) {
   e.preventDefault();
   const errorEl = document.getElementById("scheduleError");
+  const successEl = document.getElementById("scheduleSuccess");
+  successEl.style.display = "none";
   const emailEl = document.getElementById("waitingEmail");
   const email = emailEl.value.trim();
   const consent = document.getElementById("marketingConsent").checked;
@@ -259,7 +270,8 @@ document.getElementById("scheduleForm").addEventListener("submit", function (e) 
     return;
   }
   errorEl.style.display = "none";
-  alert("Thank you! We'll let you know when scheduling becomes available.");
+  successEl.textContent = "Thank you! We'll let you know when scheduling becomes available.";
+  successEl.style.display = "block";
   this.reset();
 });
 

--- a/style.min.css
+++ b/style.min.css
@@ -379,8 +379,22 @@ a:visited {
 
 .error-message {
   color: #f06859;
+  background: #ffd6d0;
+  border: 1px solid #f06859;
   font-size: 14px;
   margin: 0 0 10px;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+.success-message {
+  color: #3771e0;
+  background: #e6f0ff;
+  border: 1px solid #3771e0;
+  font-size: 14px;
+  margin: 0 0 10px;
+  padding: 10px;
+  border-radius: 4px;
 }
 
 .required-indicator {


### PR DESCRIPTION
## Summary
- add error container for the link generator
- provide success message display for the waiting list form
- remove alert messages in script and switch to inline messages
- style form messages with borders and background colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc456a8c8832991ffa040dd93c97c