### PR TITLE
Improve inline validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
           autocomplete="off"
         />
         <button onclick="startVideoCall()">Start Video Call</button>
+        <p id="instantError" class="error-message" style="display: none"></p>
 
         <!-- E2EE Toggle -->
         <div class="toggle-container">
@@ -141,6 +142,7 @@
           for 1 month.
         </div>
         <button onclick="generateRoomLink()">Generate Link</button>
+        <p id="generateError" class="error-message" style="display: none"></p>
         <div class="toggle-container">
           <label class="switch">
             <input
@@ -191,6 +193,7 @@
           To schedule meetings and webinars, you'll need a Digital Samba Free account. Join our waiting list and we'll notify you as soon as it's ready.
         </div>
         <p id="scheduleError" class="error-message" style="display: none"></p>
+        <p id="scheduleSuccess" class="success-message" style="display: none"></p>
         <input
           type="email"
           id="waitingEmail"

--- a/script.min.js
+++ b/script.min.js
@@ -11,13 +11,17 @@ async function startVideoCall() {
   //
   const teamName = "free";
   const apiUrl = `https://api.digitalsamba.com/api/public/${teamName}`;
-  const name = document.getElementById("name").value.trim();
+  const nameInput = document.getElementById("name");
+  const errorEl = document.getElementById("instantError");
+  const name = nameInput.value.trim();
   const htmlTitle = `${name}'s Digital Samba Meeting`;
 
   if (!name) {
-    alert("Please enter your name.");
+    errorEl.textContent = "Please enter your name.";
+    errorEl.style.display = "block";
     return;
   }
+  errorEl.style.display = "none";
 
   const e2eeEnabled = document.getElementById("e2eeToggle").checked;
   const newTab = window.open("", "_blank");
@@ -65,7 +69,8 @@ async function startVideoCall() {
       : (window.location.href = joinUrl);
   } catch (error) {
     if (newTab) newTab.close();
-    alert("Failed to start the video call.");
+    errorEl.textContent = "Failed to start the video call.";
+    errorEl.style.display = "block";
   }
 }
 
@@ -186,6 +191,8 @@ async function generateRoomLink() {
   const btn = document.querySelector("#generateForm button");
   btn.disabled = true;
   btn.textContent = "Generating...";
+  const errorElGen = document.getElementById("generateError");
+  if (errorElGen) errorElGen.style.display = "none";
 
   try {
     const now = new Date();
@@ -207,6 +214,7 @@ async function generateRoomLink() {
 
     const data = await response.json();
     const link = data.room_url;
+    if (errorElGen) errorElGen.style.display = "none";
 
     document.getElementById("generateForm").style.display = "none";
     document.getElementById("generatedBox").style.display = "block";
@@ -217,9 +225,11 @@ async function generateRoomLink() {
 
     const copyBtn = document.getElementById("copyLinkButton");
     copyBtn.innerHTML = "Copy link";
-  } catch (error) {
-    alert("Failed to generate the room link.");
-  } finally {
+    } catch (error) {
+      const errorEl = document.getElementById("generateError");
+      errorEl.textContent = "Failed to generate the room link.";
+      errorEl.style.display = "block";
+    } finally {
     btn.disabled = false;
     btn.textContent = "Generate Room Link";
   }
@@ -239,9 +249,10 @@ document.getElementById("copyLinkButton").addEventListener("click", function () 
 });
 
 // Waiting list form submission
-document.getElementById("scheduleForm").addEventListener("submit", function (e) {
+  document.getElementById("scheduleForm").addEventListener("submit", function (e) {
   e.preventDefault();
   const errorEl = document.getElementById("scheduleError");
+  const successEl = document.getElementById("scheduleSuccess");
   const emailEl = document.getElementById("waitingEmail");
   const email = emailEl.value.trim();
   const consent = document.getElementById("marketingConsent").checked;
@@ -256,10 +267,12 @@ document.getElementById("scheduleForm").addEventListener("submit", function (e) 
   if (message) {
     errorEl.textContent = message;
     errorEl.style.display = "block";
+    successEl.style.display = "none";
     return;
   }
   errorEl.style.display = "none";
-  alert("Thank you! We'll let you know when scheduling becomes available.");
+  successEl.textContent = "Thank you! We'll let you know when scheduling becomes available.";
+  successEl.style.display = "block";
   this.reset();
 });
 

--- a/style.min.css
+++ b/style.min.css
@@ -379,6 +379,20 @@ a:visited {
 
 .error-message {
   color: #f06859;
+  background-color: #ffe5e0;
+  border: 1px solid #f06859;
+  padding: 10px;
+  border-radius: 4px;
+  font-size: 14px;
+  margin: 0 0 10px;
+}
+
+.success-message {
+  color: #3771e0;
+  background-color: #e0ecff;
+  border: 1px solid #3771e0;
+  padding: 10px;
+  border-radius: 4px;
   font-size: 14px;
   margin: 0 0 10px;
 }


### PR DESCRIPTION
## Summary
- replace alert-based messages with inline messages
- style error and success messages with a border and background colour
- add inline feedback elements to HTML forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc456a8c8832991ffa040dd93c97c