### PR TITLE
Move validation messages below fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
           onkeypress="handleKeyPress(event)"
           autocomplete="off"
         />
+        <p id="startError" class="error-message" style="display: none"></p>
         <button onclick="startVideoCall()">Start Video Call</button>
 
         <!-- E2EE Toggle -->
@@ -130,7 +131,6 @@
             </span>
           </div>
         </div>
-        <p id="startError" class="error-message" style="display: none"></p>
       </div>
     </div>
 
@@ -192,21 +192,23 @@
         <div class="instructions">
           To schedule meetings and webinars, you'll need a Digital Samba Free account. Join our waiting list and we'll notify you as soon as it's ready.
         </div>
-        <p id="scheduleError" class="error-message" style="display: none"></p>
-        <p id="scheduleSuccess" class="success-message" style="display: none"></p>
         <input
           type="email"
           id="waitingEmail"
           placeholder="Your email address"
           required
         />
+        <p id="scheduleEmailError" class="error-message" style="display: none"></p>
         <label class="checkbox-container">
           <input type="checkbox" id="marketingConsent" required />
           <span>
-            I agree to receive updates and marketing communication from Digital Samba.<span class="required-indicator">*</span>
+            I agree to receive updates and marketing communication from Digital
+            Samba.<span class="required-indicator">*</span>
           </span>
         </label>
+        <p id="scheduleConsentError" class="error-message" style="display: none"></p>
         <button type="submit">Join Waiting List</button>
+        <p id="scheduleSuccess" class="success-message" style="display: none"></p>
       </form>
     </div>
 

--- a/script.min.js
+++ b/script.min.js
@@ -250,26 +250,39 @@ document.getElementById("copyLinkButton").addEventListener("click", function () 
 // Waiting list form submission
 document.getElementById("scheduleForm").addEventListener("submit", function (e) {
   e.preventDefault();
-  const errorEl = document.getElementById("scheduleError");
+  const emailErrorEl = document.getElementById("scheduleEmailError");
+  const consentErrorEl = document.getElementById("scheduleConsentError");
   const successEl = document.getElementById("scheduleSuccess");
+
+  emailErrorEl.style.display = "none";
+  consentErrorEl.style.display = "none";
   successEl.style.display = "none";
+
   const emailEl = document.getElementById("waitingEmail");
   const email = emailEl.value.trim();
   const consent = document.getElementById("marketingConsent").checked;
-  let message = "";
+
+  let hasError = false;
   if (!email) {
-    message = "Please enter your email address.";
+    emailErrorEl.textContent = "Please enter your email address.";
+    emailErrorEl.style.display = "block";
+    hasError = true;
   } else if (!emailEl.checkValidity()) {
-    message = "Please enter a valid email address.";
-  } else if (!consent) {
-    message = "Please accept marketing communication to join the waiting list. We'll need to let you know when it's ready.";
+    emailErrorEl.textContent = "Please enter a valid email address.";
+    emailErrorEl.style.display = "block";
+    hasError = true;
   }
-  if (message) {
-    errorEl.textContent = message;
-    errorEl.style.display = "block";
+
+  if (!consent) {
+    consentErrorEl.textContent = "Please accept marketing communication to join the waiting list. We'll need to let you know when it's ready.";
+    consentErrorEl.style.display = "block";
+    hasError = true;
+  }
+
+  if (hasError) {
     return;
   }
-  errorEl.style.display = "none";
+
   successEl.textContent = "Thank you! We'll let you know when scheduling becomes available.";
   successEl.style.display = "block";
   this.reset();


### PR DESCRIPTION
## Summary
- show name validation message directly under the name field
- move waiting list validation messages directly under their fields
- update JavaScript to display new field-specific errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68501f34737c8329a41e07cef44ade4c