### PR TITLE
Fix schedule checkbox alignment

### DIFF
--- a/style.min.css
+++ b/style.min.css
@@ -370,6 +370,10 @@ a:visited {
   gap: 8px;
   font-size: 14px;
   color: #333;
+  width: 100%;
+  max-width: 500px;
+  text-align: left;
+  align-self: flex-start;
 }
 
 .waiting-list-form input[type="checkbox"] {


### PR DESCRIPTION
## Summary
- left align checkbox consent label text
- constrain consent label width to match input width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851cf1b47a88329b90966a9e6d5107a